### PR TITLE
A few additions

### DIFF
--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -154,7 +154,7 @@
 %
 % \DescribeMacro{\dontFillFirstLine}
 %
-% This macro reverses the effect of \verb!\fillFirstLine!, so that the first line is not streched.
+% This macro reverses the effect of \verb!\fillFirstLine!, so that the text in the second argument is not streched.
 %
 % \StopEventually{}
 %

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -223,7 +223,7 @@
 %
 %    \begin{macrocode}
 \ifnum\numOfChars>1%
-    \coloredlettrinewithquote{#1}{#2}{\afterInitial}%
+    \coloredlettrinewithhangingpunctuation{#1}{#2}{\afterInitial}%
 \else%
     \lettrine[#1]{%
         \rlap{\color{\EBLettrineBackColor} #2}%
@@ -237,7 +237,7 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\newcommand{\coloredlettrinewithquote}[3]{%
+\newcommand{\coloredlettrinewithhangingpunctuation}[3]{%
     \StrRight{#2}{1}[\theLetter]%
     \newcount\charsMinusOne
     \charsMinusOne = \numOfChars

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -45,7 +45,8 @@
 %</driver>
 % \fi
 %
-% \CheckSum{30}
+% \CheckSum{0}
+% \MaybeStop
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -104,6 +105,17 @@
 % you can use the settings files described in the \texttt{lettrine} package.
 % This package contains an example making use of a \texttt{lettrine.cfg} file.
 %
+% If there is a punctuation mark before the initial, you can write it with the
+% letter in the first argument: \verb!\colouredlettrine{"T}{his is an example"}!
+% This feature has been added specifically for the EB Garamond Initials font,
+% where quotation marks and inverted question and exclamation marks with a width
+% of zero have been implemented to set hanging punctuation. If you are using a
+% different font, or want to set punctuation or something else in a different way,
+% you can use the \emph{ante} option inherited from the \verb!\lettrine! command.
+%
+% \DescribeMacro{\clrlet}
+%
+% This is a short alias for \verb!\coloredlettrine!.
 %
 % \section{Settings}
 %
@@ -130,6 +142,19 @@
 % Set the color used to typeset the foreground letters,
 % as passed to \texttt{xcolor}.
 %
+% \DescribeMacro{\fillFirstLine}
+%
+% When this macro is called, the second argument of all
+% subsequent \verb!\colouredlettrine! calls is streched to
+% the remaining linewidth (technically columnwidth),
+% until \verb!\dontFillFirstLine! is called. This is useful
+% if you want the entire first line after the initial to be
+% set in a certain way (small caps by default).
+% This macro has no arguments.
+%
+% \DescribeMacro{\dontFillFirstLine}
+%
+% This macro reverses the effect of \verb!\fillFirstLine!, so that the first line is not streched.
 %
 % \StopEventually{}
 %
@@ -187,9 +212,20 @@
 %
 %    \begin{macrocode}
 \newif\iffirstLineFilled \firstLineFilledfalse
+%    \end{macrocode}
+% \begin{macro}{\fillFirstLine}
+%    \begin{macrocode}
 \newcommand{\fillFirstLine}{\firstLineFilledtrue}
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}{\dontFillFirstLine}
+% \begin{macrocode}
 \newcommand{\dontFillFirstLine}{\firstLineFilledfalse}
+%    \end{macrocode}
+% \end{macro}
+
 %
+%    \begin{macrocode}
 \newcommand{\afterInitial}{}
 \newcommand{\LhangInPt}{\fpeval{\LettrineWidth * \DefaultLhang}pt}
 \newcommand{\firstLineWidth}{\fpeval{\columnwidth - \LettrineWidth - \DefaultFindent + \LhangInPt +0.001}pt}
@@ -233,10 +269,6 @@
 }%
 %    \end{macrocode}
 %    \begin{macrocode}
-\newcommand{\clrlet}{\coloredlettrine}
-%    \end{macrocode}
-%
-%    \begin{macrocode}
 \newcommand{\coloredlettrinewithhangingpunctuation}[3]{%
     \StrRight{#2}{1}[\theLetter]%
     \newcount\charsMinusOne
@@ -250,6 +282,13 @@
     }{#3}%
 }
 %    \end{macrocode}
+%
+% \begin{macro}{\clrlet}
+%    \begin{macrocode}
+\newcommand{\clrlet}{\coloredlettrine}
+%    \end{macrocode}
+% \end{macro}
+%
 %
 % \iffalse
 %</package>

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -144,7 +144,7 @@
 \RequirePackage{fontspec}
 \RequirePackage{lettrine}
 \RequirePackage[svgnames]{xcolor}
-\RequirePackage{xstring, xifthen, xfp}
+\RequirePackage{xstring, xfp}
 %    \end{macrocode}
 %
 % \begin{macro}{\EBLettrineBackFontname}
@@ -186,9 +186,10 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\newcommand{\shallFirstLineBeFilled}{0}
-\newcommand{\fillFirstLine}{\renewcommand{\shallFirstLineBeFilled}{1}}
-\newcommand{\dontFillFirstLine}{\renewcommand{\shallFirstLineBeFilled}{0}}
+\newif\iffirstLineFilled \firstLineFilledfalse
+\newcommand{\fillFirstLine}{\firstLineFilledtrue}
+\newcommand{\dontFillFirstLine}{\firstLineFilledfalse}
+%
 \newcommand{\afterInitial}{}
 \newcommand{\LhangInPt}{\fpeval{\LettrineWidth * \DefaultLhang}pt}
 \newcommand{\firstLineWidth}{\fpeval{\columnwidth - \LettrineWidth - \DefaultFindent + \LhangInPt +0.001}pt}
@@ -208,11 +209,11 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-\ifthenelse{\shallFirstLineBeFilled > 0}{%
+\iffirstLineFilled
   \renewcommand{\afterInitial}{\makebox[\firstLineWidth][s]{#3}}
-}{%
+\else
   \renewcommand{\afterInitial}{#3}
-}%
+\fi
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -221,14 +222,14 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ifthenelse{\numOfChars > 1}{%
+\ifnum\numOfChars>1%
     \coloredlettrinewithquote{#1}{#2}{\afterInitial}%
-}{%
+\else%
     \lettrine[#1]{%
         \rlap{\color{\EBLettrineBackColor} #2}%
         {\EBLettrineFrontFont\color{\EBLettrineFrontColor} #2}%
     }{\afterInitial}%
-}
+\fi
 }%
 %    \end{macrocode}
 %    \begin{macrocode}

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -160,7 +160,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\EBLettrineFrontFontname}
+% \begin{macro}{\EBLettrineFullFontname}
 %    \begin{macrocode}
 \newcommand{\EBLettrineFullFontname}{EBGaramondInitials}
 %    \end{macrocode}

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -144,6 +144,7 @@
 \RequirePackage{fontspec}
 \RequirePackage{lettrine}
 \RequirePackage[svgnames]{xcolor}
+\RequirePackage{xstring, xifthen, xfp}
 %    \end{macrocode}
 %
 % \begin{macro}{\EBLettrineBackFontname}
@@ -159,6 +160,11 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\EBLettrineFrontFontname}
+%    \begin{macrocode}
+\newcommand{\EBLettrineFullFontname}{EBGaramondInitials}
+%    \end{macrocode}
+% \end{macro}
 %
 % \begin{macro}{\EBLettrineBackColor}
 %    \begin{macrocode}
@@ -176,6 +182,16 @@
 %    \begin{macrocode}
 \newfontfamily\EBLettrineBackFont{\EBLettrineBackFontname}
 \newfontfamily\EBLettrineFrontFont{\EBLettrineFrontFontname}
+\newfontfamily\EBLettrineFullFont{\EBLettrineFullFontname}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\newcommand{\shallFirstLineBeFilled}{0}
+\newcommand{\fillFirstLine}{\renewcommand{\shallFirstLineBeFilled}{1}}
+\newcommand{\dontFillFirstLine}{\renewcommand{\shallFirstLineBeFilled}{0}}
+\newcommand{\afterInitial}{}
+\newcommand{\LhangInPt}{\fpeval{\LettrineWidth * \DefaultLhang}pt}
+\newcommand{\firstLineWidth}{\fpeval{\columnwidth - \LettrineWidth - \DefaultFindent + \LhangInPt +0.001}pt}
 %    \end{macrocode}
 %
 % \begin{macro}{\coloredlettrine}
@@ -192,9 +208,42 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-\lettrine[#1]{%
-\rlap{\color{\EBLettrineBackColor} #2}%
-     {\EBLettrineFrontFont\color{\EBLettrineFrontColor} #2}}{#3}%
+\ifthenelse{\shallFirstLineBeFilled > 0}{%
+  \renewcommand{\afterInitial}{\makebox[\firstLineWidth][s]{#3}}
+}{%
+  \renewcommand{\afterInitial}{#3}
+}%
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\def\givenString{#2}
+\StrLen{\givenString}[\numOfChars]
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\ifthenelse{\numOfChars > 1}{%
+    \coloredlettrinewithquote{#1}{#2}{\afterInitial}%
+}{%
+    \lettrine[#1]{%
+        \rlap{\color{\EBLettrineBackColor} #2}%
+        {\EBLettrineFrontFont\color{\EBLettrineFrontColor} #2}%
+    }{\afterInitial}%
+}
+}%
+%    \end{macrocode}
+%    \begin{macrocode}
+\newcommand{\clrlet}{\coloredlettrine}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\newcommand{\coloredlettrinewithquote}[3]{%
+    \StrRight{#2}{1}[\theletter]%
+    \StrLeft{#2}{1}[\thequotechar]%
+    \lettrine[#1,]{%
+        {\EBLettrineFullFont\thequotechar}%
+        \rlap{\color{\EBLettrineBackColor}\theletter}%
+        {\EBLettrineFrontFont\color{\EBLettrineFrontColor}\theletter}%
+    }{#3}%
 }
 %    \end{macrocode}
 %

--- a/coloredlettrine.dtx
+++ b/coloredlettrine.dtx
@@ -238,12 +238,15 @@
 %
 %    \begin{macrocode}
 \newcommand{\coloredlettrinewithquote}[3]{%
-    \StrRight{#2}{1}[\theletter]%
-    \StrLeft{#2}{1}[\thequotechar]%
+    \StrRight{#2}{1}[\theLetter]%
+    \newcount\charsMinusOne
+    \charsMinusOne = \numOfChars
+    \advance\charsMinusOne by -1
+    \StrLeft{#2}{\charsMinusOne}[\theOtherChars]%
     \lettrine[#1,]{%
-        {\EBLettrineFullFont\thequotechar}%
-        \rlap{\color{\EBLettrineBackColor}\theletter}%
-        {\EBLettrineFrontFont\color{\EBLettrineFrontColor}\theletter}%
+        {\EBLettrineFullFont\theOtherChars}%
+        \rlap{\color{\EBLettrineBackColor}\theLetter}%
+        {\EBLettrineFrontFont\color{\EBLettrineFrontColor}\theLetter}%
     }{#3}%
 }
 %    \end{macrocode}

--- a/lettrine.cfg
+++ b/lettrine.cfg
@@ -1,7 +1,5 @@
-\setcounter{DefaultLines}{3}
-%%
-%% These are *decimal* numbers:
-\renewcommand{\DefaultLoversize}{0.1}
-\renewcommand{\DefaultLraise}{0.25}
-\renewcommand{\DefaultFindent}{0.15em}
+\setcounter{DefaultLines}{4}
+\renewcommand{\DefaultLoversize}{-0.249461935032}
+\renewcommand{\DefaultLraise}{0.266022007336}
+\renewcommand{\DefaultFindent}{.4em}
 \renewcommand{\DefaultNindent}{0pt}


### PR DESCRIPTION
# Quotation Marks

We added quotation marks to the font (see [#139](https://github.com/georgd/EB-Garamond/pull/139) and [#140](https://github.com/georgd/EB-Garamond/pull/140) of EB Garamond). I changed the `coloredlettrine` command and created a new command `coloredlettrinewithquote` – which is called internally – to accompany that.

# Fill First Line

If you call `\fillFirstLine`, the text in the second mandatory argument is streched to the remaining line width, until you call `\dontFillFirstLine`. Also works in columns. The available space is calculated with `DefaultLhang`, so it does not work if a left hang is set in the optional parameters of the `(colored)lettrine` command.

# Other

I also made a shorthand `clrlet` for `coloredlettrine` and changed the default values in the lettrine config file.

------
```tex
    \fillFirstLine
    \clrlet{“A}{book of modern social in-} quiry has a shape that ...
```

![grafik](https://user-images.githubusercontent.com/32984729/221368523-a237dce5-ae7f-4a46-8585-eee428ffe3f2.png)


------

I will see, what I can do with needspace. Currently, it doesn't exactly do what I expected.